### PR TITLE
Open articles in detail view

### DIFF
--- a/app/app/Models/Article.swift
+++ b/app/app/Models/Article.swift
@@ -4,8 +4,12 @@ struct Article: Identifiable {
     let id: Int
     let title: String
     let summary: String
+    /// Full text of the article
+    let content: String
     let source: String
     let publishedDate: String
+    /// Web URL for the full article
+    let url: String
     let imageUrl: String?
     let isLive: Bool
     let isTrending: Bool

--- a/app/app/Models/FeaturedArticle.swift
+++ b/app/app/Models/FeaturedArticle.swift
@@ -4,8 +4,12 @@ struct FeaturedArticle: Identifiable {
     let id = UUID()
     let title: String
     let summary: String
+    /// Full text of the article
+    let content: String
     let source: String
     let publishedDate: String
+    /// Web URL for the feature article
+    let url: String
     let imageUrl: String
     let isLive: Bool
 }

--- a/app/app/ViewModels/NewsViewModel.swift
+++ b/app/app/ViewModels/NewsViewModel.swift
@@ -14,8 +14,10 @@ class NewsViewModel: ObservableObject {
         featuredArticle = FeaturedArticle(
             title: "Global Climate Summit Reaches Historic Agreement on Carbon Emissions",
             summary: "World leaders from 195 countries have reached a groundbreaking consensus on reducing carbon emissions by 50% over the next decade, marking the most significant climate action in international history.",
+            content: "World leaders from 195 countries have reached a groundbreaking consensus on reducing carbon emissions by 50% over the next decade. This agreement marks the most significant climate action in international history and sets ambitious targets for participating nations.",
             source: "The Times",
             publishedDate: "2 hours ago",
+            url: "https://example.com/global-climate-summit",
             imageUrl: "https://images.unsplash.com/photo-1569163139394-de4e4f43e4e3?w=800&h=400&fit=crop",
             isLive: true
         )
@@ -26,8 +28,10 @@ class NewsViewModel: ObservableObject {
                     id: 1,
                     title: "Tech Giants Face New Regulatory Challenges in European Markets",
                     summary: "New legislation targeting major technology companies could reshape the digital landscape across Europe, with potential impacts on global operations.",
+                    content: "New legislation targeting major technology companies could reshape the digital landscape across Europe, with potential impacts on global operations. Industry leaders are preparing for sweeping regulations that aim to increase transparency and user privacy.",
                     source: "Business Desk",
                     publishedDate: "4 hours ago",
+                    url: "https://example.com/tech-giants-europe",
                     imageUrl: "https://images.unsplash.com/photo-1560472355-536de3962603?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: true
@@ -36,8 +40,10 @@ class NewsViewModel: ObservableObject {
                     id: 2,
                     title: "Breakthrough in Quantum Computing Promises Revolutionary Changes",
                     summary: "Scientists at leading research institutions have achieved a major milestone in quantum computing that could accelerate technological advancement.",
+                    content: "Scientists at leading research institutions have achieved a major milestone in quantum computing that could accelerate technological advancement. Experts believe this breakthrough will pave the way for new innovations across multiple industries.",
                     source: "Science",
                     publishedDate: "6 hours ago",
+                    url: "https://example.com/quantum-computing-breakthrough",
                     imageUrl: "https://images.unsplash.com/photo-1518709268805-4e9042af2176?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -46,8 +52,10 @@ class NewsViewModel: ObservableObject {
                     id: 3,
                     title: "Global Food Security Initiative Launches Across 50 Countries",
                     summary: "A comprehensive program aimed at addressing food insecurity worldwide has been launched with support from international organizations and governments.",
+                    content: "A comprehensive program aimed at addressing food insecurity worldwide has been launched with support from international organizations and governments. The initiative seeks to coordinate relief efforts and promote sustainable agriculture.",
                     source: "World News",
                     publishedDate: "8 hours ago",
+                    url: "https://example.com/global-food-security",
                     imageUrl: "https://images.unsplash.com/photo-1574323347407-f5e1ad6d020b?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -58,8 +66,10 @@ class NewsViewModel: ObservableObject {
                     id: 4,
                     title: "European Union Announces New Trade Partnership with Southeast Asia",
                     summary: "Historic agreement aims to boost economic cooperation and sustainable development across regions.",
+                    content: "Historic agreement aims to boost economic cooperation and sustainable development across regions. Officials say the partnership will lower tariffs and create new opportunities for businesses on both continents.",
                     source: "World News",
                     publishedDate: "3 hours ago",
+                    url: "https://example.com/eu-trade-partnership",
                     imageUrl: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -68,8 +78,10 @@ class NewsViewModel: ObservableObject {
                     id: 5,
                     title: "Antarctic Research Station Reports Record Ice Sheet Changes",
                     summary: "Scientists document unprecedented changes in polar ice formations with global implications.",
+                    content: "Scientists document unprecedented changes in polar ice formations with global implications. The findings raise concerns about rising sea levels and the impact of climate change on fragile ecosystems.",
                     source: "Science",
                     publishedDate: "5 hours ago",
+                    url: "https://example.com/antarctic-ice-changes",
                     imageUrl: nil,
                     isLive: false,
                     isTrending: false
@@ -80,8 +92,10 @@ class NewsViewModel: ObservableObject {
                     id: 6,
                     title: "Congressional Leaders Reach Bipartisan Infrastructure Agreement",
                     summary: "Landmark legislation promises major investments in clean energy and digital connectivity.",
+                    content: "Landmark legislation promises major investments in clean energy and digital connectivity. The agreement is expected to generate thousands of jobs and modernize aging transportation networks.",
                     source: "Politics",
                     publishedDate: "2 hours ago",
+                    url: "https://example.com/infrastructure-agreement",
                     imageUrl: "https://images.unsplash.com/photo-1529107386315-e1a2ed48a620?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -92,8 +106,10 @@ class NewsViewModel: ObservableObject {
                     id: 7,
                     title: "New Gene Therapy Shows Promise for Treating Rare Genetic Disorders",
                     summary: "Clinical trials demonstrate significant improvements in patient outcomes using innovative treatment approach.",
+                    content: "Clinical trials demonstrate significant improvements in patient outcomes using an innovative treatment approach. Researchers are optimistic about future applications to a wide range of genetic diseases.",
                     source: "Health & Science",
                     publishedDate: "4 hours ago",
+                    url: "https://example.com/gene-therapy-promise",
                     imageUrl: "https://images.unsplash.com/photo-1559757148-5c350d0d3c56?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -104,8 +120,10 @@ class NewsViewModel: ObservableObject {
                     id: 8,
                     title: "AI Breakthrough: New Model Achieves Human-Level Performance in Complex Reasoning",
                     summary: "Latest artificial intelligence system demonstrates unprecedented capabilities in problem-solving and analysis.",
+                    content: "Latest artificial intelligence system demonstrates unprecedented capabilities in problem-solving and analysis. The breakthrough could transform industries from healthcare to finance, experts say.",
                     source: "Technology",
                     publishedDate: "1 hour ago",
+                    url: "https://example.com/ai-breakthrough",
                     imageUrl: "https://images.unsplash.com/photo-1485827404703-89b55fcc595e?w=400&h=300&fit=crop",
                     isLive: true,
                     isTrending: false

--- a/app/app/Views/ArticleDetailView.swift
+++ b/app/app/Views/ArticleDetailView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct ArticleDetailView: View {
+    let title: String
+    let content: String
+    let source: String
+    let publishedDate: String
+    let url: String
+    let imageUrl: String?
+
+    init(article: Article) {
+        self.title = article.title
+        self.content = article.content
+        self.source = article.source
+        self.publishedDate = article.publishedDate
+        self.url = article.url
+        self.imageUrl = article.imageUrl
+    }
+
+    init(featuredArticle: FeaturedArticle) {
+        self.title = featuredArticle.title
+        self.content = featuredArticle.content
+        self.source = featuredArticle.source
+        self.publishedDate = featuredArticle.publishedDate
+        self.url = featuredArticle.url
+        self.imageUrl = featuredArticle.imageUrl
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if let imageUrl, let img = URL(string: imageUrl) {
+                    AsyncImage(url: img) { image in
+                        image.resizable().aspectRatio(contentMode: .fill)
+                    } placeholder: {
+                        Color.gray.opacity(0.3)
+                    }
+                    .frame(height: 200)
+                    .clipped()
+                }
+
+                Text(title)
+                    .font(.title2)
+                    .bold()
+
+                HStack(spacing: 4) {
+                    Text(source)
+                    Text("•")
+                    Text(publishedDate)
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+                Text(content)
+                    .font(.body)
+
+                Link("Read full story", destination: URL(string: url)!)
+                    .font(.footnote)
+                    .padding(.top)
+
+                Spacer()
+            }
+            .padding()
+        }
+        .navigationTitle("Article")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    ArticleDetailView(article: Article(
+        id: 0,
+        title: "Example",
+        summary: "summary",
+        content: "content",
+        source: "source",
+        publishedDate: "1h",
+        url: "https://example.com",
+        imageUrl: nil,
+        isLive: false,
+        isTrending: false
+    ))
+}

--- a/app/app/Views/ContentView.swift
+++ b/app/app/Views/ContentView.swift
@@ -33,14 +33,18 @@ struct ContentView: View {
                 CategoryTabs(selected: $viewModel.selectedCategory)
                     .listRowInsets(EdgeInsets())
                 if viewModel.selectedCategory == .top {
-                    FeaturedArticleView(article: viewModel.featuredArticle)
-                        .listRowInsets(EdgeInsets())
+                    NavigationLink(destination: ArticleDetailView(featuredArticle: viewModel.featuredArticle)) {
+                        FeaturedArticleView(article: viewModel.featuredArticle)
+                    }
+                    .listRowInsets(EdgeInsets())
                     SectionHeaderView(title: "Latest News", subtitle: "Stay updated with breaking stories")
                         .listRowInsets(EdgeInsets())
                 }
                 ForEach(viewModel.articlesByCategory[viewModel.selectedCategory] ?? []) { article in
-                    ArticleRow(article: article)
-                        .listRowInsets(EdgeInsets())
+                    NavigationLink(destination: ArticleDetailView(article: article)) {
+                        ArticleRow(article: article)
+                    }
+                    .listRowInsets(EdgeInsets())
                 }
             }
             .listStyle(.plain)

--- a/app/app/Views/FeaturedArticleView.swift
+++ b/app/app/Views/FeaturedArticleView.swift
@@ -43,5 +43,12 @@ struct FeaturedArticleView: View {
 
 #Preview {
     FeaturedArticleView(article: FeaturedArticle(
-        title: "Example", summary: "summary", source: "source", publishedDate: "1h", imageUrl: "", isLive: true))
+        title: "Example",
+        summary: "summary",
+        content: "content",
+        source: "source",
+        publishedDate: "1h",
+        url: "https://example.com",
+        imageUrl: "",
+        isLive: true))
 }


### PR DESCRIPTION
## Summary
- introduce `content` property to article models
- add `ArticleDetailView` to show full text inside the app
- open article rows and featured article inside a navigation link

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6864f3bac314832eaeb8af70c02524f9