### PR TITLE
Open articles via external links

### DIFF
--- a/app/app/Models/Article.swift
+++ b/app/app/Models/Article.swift
@@ -6,6 +6,8 @@ struct Article: Identifiable {
     let summary: String
     let source: String
     let publishedDate: String
+    /// Web URL for the full article
+    let url: String
     let imageUrl: String?
     let isLive: Bool
     let isTrending: Bool

--- a/app/app/Models/FeaturedArticle.swift
+++ b/app/app/Models/FeaturedArticle.swift
@@ -6,6 +6,8 @@ struct FeaturedArticle: Identifiable {
     let summary: String
     let source: String
     let publishedDate: String
+    /// Web URL for the feature article
+    let url: String
     let imageUrl: String
     let isLive: Bool
 }

--- a/app/app/ViewModels/NewsViewModel.swift
+++ b/app/app/ViewModels/NewsViewModel.swift
@@ -16,6 +16,7 @@ class NewsViewModel: ObservableObject {
             summary: "World leaders from 195 countries have reached a groundbreaking consensus on reducing carbon emissions by 50% over the next decade, marking the most significant climate action in international history.",
             source: "The Times",
             publishedDate: "2 hours ago",
+            url: "https://example.com/global-climate-summit",
             imageUrl: "https://images.unsplash.com/photo-1569163139394-de4e4f43e4e3?w=800&h=400&fit=crop",
             isLive: true
         )
@@ -28,6 +29,7 @@ class NewsViewModel: ObservableObject {
                     summary: "New legislation targeting major technology companies could reshape the digital landscape across Europe, with potential impacts on global operations.",
                     source: "Business Desk",
                     publishedDate: "4 hours ago",
+                    url: "https://example.com/tech-giants-europe",
                     imageUrl: "https://images.unsplash.com/photo-1560472355-536de3962603?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: true
@@ -38,6 +40,7 @@ class NewsViewModel: ObservableObject {
                     summary: "Scientists at leading research institutions have achieved a major milestone in quantum computing that could accelerate technological advancement.",
                     source: "Science",
                     publishedDate: "6 hours ago",
+                    url: "https://example.com/quantum-computing-breakthrough",
                     imageUrl: "https://images.unsplash.com/photo-1518709268805-4e9042af2176?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -48,6 +51,7 @@ class NewsViewModel: ObservableObject {
                     summary: "A comprehensive program aimed at addressing food insecurity worldwide has been launched with support from international organizations and governments.",
                     source: "World News",
                     publishedDate: "8 hours ago",
+                    url: "https://example.com/global-food-security",
                     imageUrl: "https://images.unsplash.com/photo-1574323347407-f5e1ad6d020b?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -60,6 +64,7 @@ class NewsViewModel: ObservableObject {
                     summary: "Historic agreement aims to boost economic cooperation and sustainable development across regions.",
                     source: "World News",
                     publishedDate: "3 hours ago",
+                    url: "https://example.com/eu-trade-partnership",
                     imageUrl: "https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -70,6 +75,7 @@ class NewsViewModel: ObservableObject {
                     summary: "Scientists document unprecedented changes in polar ice formations with global implications.",
                     source: "Science",
                     publishedDate: "5 hours ago",
+                    url: "https://example.com/antarctic-ice-changes",
                     imageUrl: nil,
                     isLive: false,
                     isTrending: false
@@ -82,6 +88,7 @@ class NewsViewModel: ObservableObject {
                     summary: "Landmark legislation promises major investments in clean energy and digital connectivity.",
                     source: "Politics",
                     publishedDate: "2 hours ago",
+                    url: "https://example.com/infrastructure-agreement",
                     imageUrl: "https://images.unsplash.com/photo-1529107386315-e1a2ed48a620?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -94,6 +101,7 @@ class NewsViewModel: ObservableObject {
                     summary: "Clinical trials demonstrate significant improvements in patient outcomes using innovative treatment approach.",
                     source: "Health & Science",
                     publishedDate: "4 hours ago",
+                    url: "https://example.com/gene-therapy-promise",
                     imageUrl: "https://images.unsplash.com/photo-1559757148-5c350d0d3c56?w=400&h=300&fit=crop",
                     isLive: false,
                     isTrending: false
@@ -106,6 +114,7 @@ class NewsViewModel: ObservableObject {
                     summary: "Latest artificial intelligence system demonstrates unprecedented capabilities in problem-solving and analysis.",
                     source: "Technology",
                     publishedDate: "1 hour ago",
+                    url: "https://example.com/ai-breakthrough",
                     imageUrl: "https://images.unsplash.com/photo-1485827404703-89b55fcc595e?w=400&h=300&fit=crop",
                     isLive: true,
                     isTrending: false

--- a/app/app/Views/BreakingNewsBanner.swift
+++ b/app/app/Views/BreakingNewsBanner.swift
@@ -19,6 +19,8 @@ struct BreakingNewsBanner: View {
     }
 }
 
-#Preview {
-    BreakingNewsBanner(message: "Supreme Court to hear landmark climate case next month")
+struct BreakingNewsBanner_Previews: PreviewProvider {
+    static var previews: some View {
+        BreakingNewsBanner(message: "Supreme Court to hear landmark climate case next month")
+    }
 }

--- a/app/app/Views/ContentView.swift
+++ b/app/app/Views/ContentView.swift
@@ -33,14 +33,22 @@ struct ContentView: View {
                 CategoryTabs(selected: $viewModel.selectedCategory)
                     .listRowInsets(EdgeInsets())
                 if viewModel.selectedCategory == .top {
-                    FeaturedArticleView(article: viewModel.featuredArticle)
+                    if let url = URL(string: viewModel.featuredArticle.url) {
+                        Link(destination: url) {
+                            FeaturedArticleView(article: viewModel.featuredArticle)
+                        }
                         .listRowInsets(EdgeInsets())
+                    }
                     SectionHeaderView(title: "Latest News", subtitle: "Stay updated with breaking stories")
                         .listRowInsets(EdgeInsets())
                 }
                 ForEach(viewModel.articlesByCategory[viewModel.selectedCategory] ?? []) { article in
-                    ArticleRow(article: article)
+                    if let url = URL(string: article.url) {
+                        Link(destination: url) {
+                            ArticleRow(article: article)
+                        }
                         .listRowInsets(EdgeInsets())
+                    }
                 }
             }
             .listStyle(.plain)

--- a/app/app/Views/FeaturedArticleView.swift
+++ b/app/app/Views/FeaturedArticleView.swift
@@ -41,7 +41,16 @@ struct FeaturedArticleView: View {
     }
 }
 
-#Preview {
-    FeaturedArticleView(article: FeaturedArticle(
-        title: "Example", summary: "summary", source: "source", publishedDate: "1h", imageUrl: "", isLive: true))
+struct FeaturedArticleView_Previews: PreviewProvider {
+    static var previews: some View {
+        FeaturedArticleView(article: FeaturedArticle(
+            title: "Example",
+            summary: "summary",
+            source: "source",
+            publishedDate: "1h",
+            url: "https://example.com",
+            imageUrl: "",
+            isLive: true
+        ))
+    }
 }

--- a/app/app/Views/SectionHeaderView.swift
+++ b/app/app/Views/SectionHeaderView.swift
@@ -18,6 +18,8 @@ struct SectionHeaderView: View {
     }
 }
 
-#Preview {
-    SectionHeaderView(title: "Latest News", subtitle: "Stay updated")
+struct SectionHeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        SectionHeaderView(title: "Latest News", subtitle: "Stay updated")
+    }
 }


### PR DESCRIPTION
## Summary
- drop the unused article detail view and `content` fields
- add `url` to article models
- link featured article and news rows directly to their URLs
- update sample data with example URLs
- replace `#Preview` macros with `PreviewProvider` to avoid build errors

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6864f3bac314832eaeb8af70c02524f9